### PR TITLE
Add self hosted runner configuration

### DIFF
--- a/.github/workflows/garm-docker-image.yaml
+++ b/.github/workflows/garm-docker-image.yaml
@@ -1,0 +1,38 @@
+name: Build and push garm docker image
+on: workflow_dispatch
+
+jobs:
+  Build-and-Push-Image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: confidential-containers/garm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        working-directory: ./github/azure-self-hosted-runners
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/github/azure-self-hosted-runners/.gitignore
+++ b/github/azure-self-hosted-runners/.gitignore
@@ -1,0 +1,2 @@
+tf/.terraform
+tf/terraform.tfvars

--- a/github/azure-self-hosted-runners/Dockerfile
+++ b/github/azure-self-hosted-runners/Dockerfile
@@ -1,0 +1,34 @@
+FROM golang:1.20.4 AS builder
+
+ARG GARM_REV=fdfcc61
+ARG GARM_PROVIDER_AZURE_REV=2f9b248
+
+RUN mkdir /src /build
+RUN git clone https://github.com/cloudbase/garm.git /src/garm
+RUN git clone https://github.com/cloudbase/garm-provider-azure /src/garm-provider-azure
+
+WORKDIR /src/garm
+RUN git checkout ${GARM_REV}
+RUN go build -o /build/garm ./cmd/garm
+RUN go build -o /build/garm-cli ./cmd/garm-cli
+
+WORKDIR /src/garm-provider-azure
+RUN git checkout ${GARM_PROVIDER_AZURE_REV}
+RUN go build -o /build/garm-provider-azure
+
+FROM debian:bullseye-slim
+
+RUN apt-get update && apt-get install -y \
+	ca-certificates \
+	gettext-base
+
+RUN mkdir -p /etc/garm /root/.local/share/garm-cli
+RUN ln -s /etc/garm/cli-config.toml /root/.local/share/garm-cli/config.toml
+
+COPY --from=builder /build/garm /usr/bin
+COPY --from=builder /build/garm-cli /usr/bin
+COPY --from=builder /build/garm-provider-azure /usr/bin
+
+COPY ./config.toml.tmpl /
+COPY ./azure-config.toml.tmpl /
+COPY ./init.sh /

--- a/github/azure-self-hosted-runners/README.md
+++ b/github/azure-self-hosted-runners/README.md
@@ -1,0 +1,119 @@
+# Self-hosted Github Runners with Garm
+
+Those instructions deploy Garm for self-hosted github runners on azure (c)VMs. Garm listens to webhooks from github and spawns VMs on demand.
+
+## Build
+
+```bash
+docker build -t garm-azure .
+```
+
+## Service
+
+The application is deployed as an [ACI](https://azure.microsoft.com/en-us/products/container-instances) Container Group. It is bootstrapped with an init container which creates an admin user, an initial repository registration, and a pool for the repository. It keeps database state on a Storage Account-backed volume. The app will expose an HTTP/S ports for github webhooks.
+
+### Requirements
+
+- Terraform
+- Azure credentials, configured and logged in.
+- A github token to manage self-hosted runner registrations, either:
+  - A classic token scoped to `public_repo`.
+  - A fine-grained token w/ access `read` access to `metadata` and `read,write` access to `administration` of particular repositories.
+
+### Deployment
+
+Create a `tf/terraform.tfvars` file with `github-token=github_pat...` or set it as env `export TF_VAR_github_token=github_pat...`.
+
+```bash
+cd tf
+terraform apply
+```
+
+## Configuration
+
+Configuration of repositories is performed via the bundled `garm-cli` tool. It's available via `az container exec` (the individual parameters might differ depending on the config & deployment):
+
+```bash
+$ az container exec -g garm -n garm-kg1ocu --container-name garm --exec-command bash
+$ garm-cli profile ls
++-----------------+-----------------------+
+| NAME            | BASE URL              |
++-----------------+-----------------------+
+| local (current) | http://localhost:9997 |
++-----------------+-----------------------+
+```
+
+### Repositories
+
+To configure a repository create a webhook secret:
+
+```bash
+$ export WEBHOOK_SECRET="$(tr -dc A-Za-z0-9 < /dev/urandom | head -c 24)"
+$ garm-cli repository add --credentials garm --name garm-playground --owner mkulke --webhook-secret "$WEBHOOK_SECRET"
++----------------------+--------------------------------------+
+| FIELD                | VALUE                                |
++----------------------+--------------------------------------+
+| ID                   | d7beb832-6feb-4739-8026-58e7d97d99cb |
+| Owner                | mkulke                               |
+| Name                 | garm-playground                      |
+| Credentials          | garm                                 |
+| Pool manager running | false                                |
+| Failure reason       |                                      |
++----------------------+--------------------------------------+
+```
+
+To react to github workflow events, the application exposes an https endpoint on the internet. You can retrieve the endpoint as `webhook_url` output from the terraform deployment (`terraform output`).
+
+Add this Webhook (e.g. `https://garm-dc6512.eastus.azurecontainer.io/webhooks`) to your repository:
+- Set the webhook secret to the value that was configured for the repo.
+- Set the webhook `Content-Type` to `application/json`. (Garm will only accept json events)
+- Check the box for `Workflow jobs` events.
+
+### Pools
+
+If the `runs-on` label selector of a github action job matches a set of tags (`runs-on: ["self-hosted", "ubuntu"]`) that is configured for a repository's pool, the service attempts to spawn a self-hosted runner.
+
+```bash
+$ garm-cli repo ls
++--------------------------------------+--------+-----------------+------------------+------------------+
+| ID                                   | OWNER  | NAME            | CREDENTIALS NAME | POOL MGR RUNNING |
++--------------------------------------+--------+-----------------+------------------+------------------+
+| d7beb832-6feb-4739-8026-58e7d97d99cb | mkulke | garm-playground | garm             | true             |
++--------------------------------------+--------+-----------------+------------------+------------------+
+$ export REPO_ID=d7beb832-6feb-4739-8026-58e7d97d99cb
+$ garm-cli pool add \
+	--repo "$REPO_ID" \
+	--flavor Standard_DC2as_v5 \
+	--tags self-hosted,azure-cvm,ubuntu-2204 \
+	--enabled true \
+	--min-idle-runners 0 \
+	--max-runners 4 \
+	--extra-specs '{"confidential": true}' \
+	--provider-name azure_external \
+	--image Canonical:0001-com-ubuntu-confidential-vm-jammy:22_04-lts-cvm:latest
+```
+
+## Debugging
+
+You can debug the webhook transmission in Github's console. If the webhook was successfully sent and picked up by Garm, it should spawn an instance. It might take a couple of minutes for the runner to be fully bootstrapped (see timestamps below). Eventually it should register itself w/ a call to `/api/v1/metadata/runner-registration-token` execute the jobs and delete the instance afterwards.
+
+```bash
+$ az container logs -g garm -n garm-kg1ocu --container-name garm --follow
+2023/06/02 12:57:16 got hook for repo kinvolk/azure-cvm-tooling
+2023/06/02 12:57:16 adding new runner with requested tags self-hosted, azure-cvm, ubuntu-2204 in pool e475e34d-05c9-42ea-9a52-bfa74b3ebaee
+127.0.0.1 - - [02/Jun/2023:12:57:16 +0000] "POST /webhooks HTTP/1.1" 200 0 "" "GitHub-Hookshot/4200660"
+2023/06/02 12:57:19 creating instance garm-Gl1EKldZ6C66 in pool e475e34d-05c9-42ea-9a52-bfa74b3ebaee
+2023/06/02 12:57:31 provider returned: {
+  "provider_id": "garm-Gl1EKldZ6C66",
+  "agent_id": 0,
+  "name": "garm-Gl1EKldZ6C66",
+  "os_type": "linux",
+  "os_name": "22_04-lts-cvm",
+  "os_version": "latest",
+  "os_arch": "amd64",
+  "status": "running",
+  "updated_at": "0001-01-01T00:00:00Z",
+  "github-runner-group": ""
+}
+127.0.0.1 - - [02/Jun/2023:13:01:21 +0000] "GET /api/v1/metadata/runner-registration-token/ HTTP/1.1" 200 29 "" "curl/7.81.0"
+```

--- a/github/azure-self-hosted-runners/azure-config.toml.tmpl
+++ b/github/azure-self-hosted-runners/azure-config.toml.tmpl
@@ -1,0 +1,7 @@
+location = "eastus"
+
+[credentials]
+subscription_id = "$SUBSCRIPTION_ID"
+
+[credentials.managed_identity]
+client_id = "$AZURE_CLIENT_ID"

--- a/github/azure-self-hosted-runners/config.toml.tmpl
+++ b/github/azure-self-hosted-runners/config.toml.tmpl
@@ -1,0 +1,121 @@
+[default]
+# This URL is used by instances to send back status messages as they install
+# the github actions runner. Status messages can be seen by querying the
+# runner status in garm.
+# Note: If you're using a reverse proxy in front of your garm installation,
+# this URL needs to point to the address of the reverse proxy. Using TLS is
+# highly encouraged.
+callback_url = "https://${GARM_HOSTNAME}/api/v1/callbacks/status"
+
+# This URL is used by instances to retrieve information they need to set themselves
+# up. Access to this URL is granted using the same JWT token used to send back
+# status updates. Once the instance transitions to "installed" or "failed" state,
+# access to both the status and metadata endpoints is disabled.
+# Note: If you're using a reverse proxy in front of your garm installation,
+# this URL needs to point to the address of the reverse proxy. Using TLS is
+# highly encouraged.
+metadata_url = "https://${GARM_HOSTNAME}/api/v1/metadata"
+
+# This folder is defined here for future use. Right now, we create a SSH
+# public/private key-pair.
+config_dir = "etc"
+
+# Uncomment this line if you'd like to log to a file instead of standard output.
+# log_file = "/tmp/runner-manager.log"
+
+# Enable streaming logs via web sockets. Use garm-cli debug-log.
+enable_log_streamer = false
+
+[metrics]
+# Toggle metrics. If set to false, the API endpoint for metrics collection will
+# be disabled.
+enable = false
+# Toggle to disable authentication (not recommended) on the metrics endpoint.
+# If you do disable authentication, I encourage you to put a reverse proxy in front
+# of garm and limit which systems can access that particular endpoint. Ideally, you
+# would enable some kind of authentication using the reverse proxy, if the built-in auth
+# is not sufficient for your needs.
+disable_auth = false
+
+[jwt_auth]
+# A JWT token secret used to sign tokens.
+# Obviously, this needs to be changed :).
+secret = "${GARM_JWT_SECRET}"
+
+# Time to live for tokens. Both the instances and you will use JWT tokens to
+# authenticate against the API. However, this TTL is applied only to tokens you
+# get when logging into the API. The tokens issued to the instances we manage,
+# have a TTL based on the runner bootstrap timeout set on each pool. The minimum
+# TTL for this token is 24h.
+time_to_live = "8760h"
+
+[apiserver]
+  # Bind the API to this IP
+  bind = "0.0.0.0"
+  # Bind the API to this port
+  port = 9997
+  # Whether or not to set up TLS for the API endpoint. If this is set to true,
+  # you must have a valid apiserver.tls section.
+  use_tls = false
+  # Set a list of allowed origins
+  # By default, if this option is ommited or empty, we will check
+  # only that the origin is the same as the originating server.
+  # A literal of "*" will allow any origin
+  # cors_origins = ["*"]
+
+[database]
+  # Turn on/off debugging for database queries.
+  debug = false
+  # Database backend to use. Currently supported backends are:
+  #   * sqlite3
+  #   * mysql
+  backend = "sqlite3"
+  # the passphrase option is a temporary measure by which we encrypt the webhook
+  # secret that gets saved to the database, using AES256. In the future, secrets
+  # will be saved to something like Barbican or Vault, eliminating the need for
+  # this. This setting needs to be 32 characters in size.
+  passphrase = "$GARM_DB_PASSPHRASE"
+  [database.sqlite3]
+    # Path on disk to the sqlite3 database file.
+    db_file = "/etc/garm/db.sqlite"
+
+[[provider]]
+name = "azure_external"
+description = "external azure provider"
+provider_type = "external"
+  [provider.external]
+  # config file passed to the executable via GARM_PROVIDER_CONFIG_FILE environment variable
+  config_file = "/etc/garm/azure-config.toml"
+  # Absolute path to an executable that implements the provider logic. This executable can be
+  # anything (bash, a binary, python, etc). See documentation in this repo on how to write an
+  # external provider.
+  provider_executable = "/usr/bin/garm-provider-azure"
+
+# This is a list of credentials that you can define as part of the repository
+# or organization definitions. They are not saved inside the database, as there
+# is no Vault integration (yet). This will change in the future.
+# Credentials defined here can be listed using the API. Obviously, only the name
+# and descriptions are returned.
+[[github]]
+  name = "garm"
+  description = "garm pat"
+  # This is a personal token with access to the repositories and organizations
+  # you plan on adding to garm. The "workflow" option needs to be selected in order
+  # to work with repositories, and the admin:org needs to be set if you plan on
+  # adding an organization.
+  oauth2_token = "$GITHUB_TOKEN"
+  # base_url (optional) is the URL at which your GitHub Enterprise Server can be accessed.
+  # If these credentials are for github.com, leave this setting blank
+  base_url = ""
+  # api_base_url (optional) is the base URL where the GitHub Enterprise Server API can be accessed.
+  # Leave this blank if these credentials are for github.com.
+  api_base_url = ""
+  # upload_base_url (optional) is the base URL where the GitHub Enterprise Server upload API can be accessed.
+  # Leave this blank if these credentials are for github.com, or if you don't have a separate URL
+  # for the upload API.
+  upload_base_url = ""
+  # ca_cert_bundle (optional) is the CA certificate bundle in PEM format that will be used by the github
+  # client to talk to the API. This bundle will also be sent to all runners as bootstrap params.
+  # Use this option if you're using a self signed certificate.
+  # Leave this blank if you're using github.com or if your certificare is signed by a valid CA.
+  ca_cert_bundle = ""

--- a/github/azure-self-hosted-runners/init.sh
+++ b/github/azure-self-hosted-runners/init.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${GARM_HOSTNAME:?required}"
+: "${GARM_JWT_SECRET:?required}"
+: "${GARM_DB_PASSPHRASE:?required}"
+: "${GITHUB_TOKEN:?required}"
+envsubst < /config.toml.tmpl > /etc/garm/config.toml
+
+: "${SUBSCRIPTION_ID:?required}"
+: "${AZURE_CLIENT_ID:?required}"
+envsubst < /azure-config.toml.tmpl > /etc/garm/azure-config.toml
+
+if [ -f /etc/garm/db.sqlite ]; then
+	echo "database already exists, skipping init"
+	exit 0
+fi
+
+echo "start garm"
+
+nohup /usr/bin/garm -config /etc/garm/config.toml & GARM_PID=$!
+sleep 10
+
+echo "initialize garm (pid $GARM_PID)"
+
+garm-cli init \
+	--name local \
+	--email root@localhost \
+	--url http://localhost:9997 \
+	--password "$GARM_ADMIN_PW" \
+	--username admin
+
+echo "stop garm (pid $GARM_PID)"
+
+kill "$GARM_PID"
+
+echo "initialization complete"

--- a/github/azure-self-hosted-runners/tf/.terraform.lock.hcl
+++ b/github/azure-self-hosted-runners/tf/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.57.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:SOBKU/ioGnpuQpAx6dgaD0EzfAM2W+uS9e6p59viSxs=",
+    "zh:028202b0ae01f1262dac076b383cb68b5dd624977669b6db833418c215eb8401",
+    "zh:26fcf9e9b73cb3bbf87a048361a89050d2e52bdc91190a305e624a62be26a3f4",
+    "zh:2f381103953e4513068eee62089a0ec8c60a18ecef2235138b6c29a45920d6a2",
+    "zh:376f016f4b449b2cf38f75e27e7a9157fdcfc925f28198124a30e316abb54f3d",
+    "zh:7d491bab94d5aba91cd9c307dbd4b655dcdc0a6212541e7800b9a902be98befe",
+    "zh:85fa7d8339efd15494f947cda02e9ed127eafa32652e568f54261b2e97d2b3ee",
+    "zh:950e079e55a7e321adbd2f6a0639a4b3b0fac47d2e4bb3a12791e0817b694238",
+    "zh:975260e09379c5c97cad3171327db2f0b4914909861d4c24ab784b0ecd79c54a",
+    "zh:a26bb67ab2d2f20e5fee4d41110584af17357f4b4266d80f9debfad61fa0a4fd",
+    "zh:da0e5d1ec301c69b6fae684e55059fc5e1b91699ed3696229f599d558401556b",
+    "zh:ea11e62ce53caec240cb3a1da25d248805387fa246314001ed3e07e9105f6e12",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.5.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/github/azure-self-hosted-runners/tf/main.tf
+++ b/github/azure-self-hosted-runners/tf/main.tf
@@ -1,0 +1,173 @@
+resource "azurerm_resource_group" "garm_rg" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_user_assigned_identity" "garm_id" {
+  name                = "garm"
+  location            = azurerm_resource_group.garm_rg.location
+  resource_group_name = azurerm_resource_group.garm_rg.name
+}
+
+data "azurerm_subscription" "current" {
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  lower   = true
+  upper   = false
+  special = false
+}
+
+resource "azurerm_role_assignment" "garm_role_as" {
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.garm_id.principal_id
+}
+
+resource "azurerm_storage_account" "garm_sa" {
+  name                     = "garm${random_string.suffix.result}"
+  resource_group_name      = azurerm_resource_group.garm_rg.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "garm_share" {
+  name                 = "garm-etc-folder"
+  storage_account_name = azurerm_storage_account.garm_sa.name
+  quota                = 10
+}
+
+resource "random_password" "garm_jwt_secret" {
+  length = 32
+}
+
+// needs to be >= 32 characters
+resource "random_password" "garm_db_passphrase" {
+  length = 32
+}
+
+resource "random_password" "garm_admin_pw" {
+  length = 32
+}
+
+locals {
+  dns_name_label = "garm-${random_string.suffix.result}"
+  fqdn           = "${local.dns_name_label}.${var.location}.azurecontainer.io"
+}
+
+resource "azurerm_container_group" "garm_aci" {
+  name                = "garm-${random_string.suffix.result}"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.garm_rg.name
+  ip_address_type     = "Public"
+  os_type             = "Linux"
+  dns_name_label      = local.dns_name_label
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.garm_id.id,
+    ]
+  }
+
+  init_container {
+    name  = "init"
+    image = var.garm_image
+
+    environment_variables = {
+      GARM_HOSTNAME   = local.fqdn
+      SUBSCRIPTION_ID = data.azurerm_subscription.current.subscription_id
+      AZURE_CLIENT_ID = azurerm_user_assigned_identity.garm_id.client_id
+    }
+
+    secure_environment_variables = {
+      GARM_JWT_SECRET    = random_password.garm_jwt_secret.result
+      GARM_DB_PASSPHRASE = random_password.garm_db_passphrase.result
+      GARM_ADMIN_PW      = random_password.garm_admin_pw.result
+      GITHUB_TOKEN       = var.github_token
+    }
+
+    volume {
+      name                 = "init"
+      mount_path           = "/etc/garm"
+      read_only            = false
+      share_name           = azurerm_storage_share.garm_share.name
+      storage_account_name = azurerm_storage_account.garm_sa.name
+      storage_account_key  = azurerm_storage_account.garm_sa.primary_access_key
+    }
+
+    commands = [
+      "/init.sh",
+    ]
+  }
+
+  container {
+    name   = "garm"
+    image  = var.garm_image
+    cpu    = "1.0"
+    memory = "0.5"
+
+    volume {
+      name                 = "garm"
+      mount_path           = "/etc/garm"
+      read_only            = false
+      share_name           = azurerm_storage_share.garm_share.name
+      storage_account_name = azurerm_storage_account.garm_sa.name
+      storage_account_key  = azurerm_storage_account.garm_sa.primary_access_key
+    }
+
+    commands = [
+      "garm",
+      "-config",
+      "/etc/garm/config.toml",
+    ]
+  }
+
+  container {
+    name   = "caddy"
+    image  = var.caddy_image
+    cpu    = "1.0"
+    memory = "0.5"
+
+    volume {
+      name                 = "caddy"
+      mount_path           = "/data"
+      read_only            = false
+      share_name           = azurerm_storage_share.garm_share.name
+      storage_account_name = azurerm_storage_account.garm_sa.name
+      storage_account_key  = azurerm_storage_account.garm_sa.primary_access_key
+    }
+
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+
+    ports {
+      port     = 443
+      protocol = "TCP"
+    }
+
+    commands = [
+      "caddy",
+      "reverse-proxy",
+      "--from",
+      local.fqdn,
+      "--to",
+      "localhost:9997",
+    ]
+  }
+}
+
+output "webhook_url" {
+  value = "https://${local.fqdn}/webhooks"
+}
+
+output "container_group_name" {
+  value = azurerm_container_group.garm_aci.name
+}

--- a/github/azure-self-hosted-runners/tf/providers.tf
+++ b/github/azure-self-hosted-runners/tf/providers.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "terraform"
+    storage_account_name = "cocotfstate"
+    container_name       = "garm"
+    key                  = "terraform.tfstate"
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/github/azure-self-hosted-runners/tf/variables.tf
+++ b/github/azure-self-hosted-runners/tf/variables.tf
@@ -1,0 +1,35 @@
+variable "resource_group_name" {
+  type        = string
+  default     = "garm"
+  description = "Name for garm resource group"
+}
+
+variable "location" {
+  type        = string
+  default     = "eastus"
+  description = "Location for all resources"
+}
+
+variable "garm_image" {
+  type        = string
+  default     = "ghcr.io/mkulke/garm:20230602"
+  description = "Container image for garm"
+}
+
+variable "caddy_image" {
+  type        = string
+  default     = "caddy:2.6.4"
+  description = "Container image for caddy"
+}
+
+variable "storage_account_name" {
+  type        = string
+  default     = "cocogarmstorage"
+  description = "Name for storage account"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Github token for garm"
+  sensitive   = true
+}


### PR DESCRIPTION
- This code includes a Garm docker build and a terraform deployment to run garm on the azure coco description.
- State is kept on a Storage Account share.
- Individual repo configs + instance pools need to be added manually to the configuration w/ `garm-cli`