### PR TITLE
garm: fix build and push workflow

### DIFF
--- a/.github/workflows/garm-docker-image.yaml
+++ b/.github/workflows/garm-docker-image.yaml
@@ -30,9 +30,8 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        working-directory: ./github/azure-self-hosted-runners
         with:
-          context: .
+          context: ./github/azure-self-hosted-runners
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixed `Unexpected value 'working-directory'` error by removing the working-directory project and switching to the context properly.

Fixes #1
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>