### PR TITLE
Add deletion prevention flag to file share

### DIFF
--- a/github/azure-self-hosted-runners/tf/main.tf
+++ b/github/azure-self-hosted-runners/tf/main.tf
@@ -40,6 +40,10 @@ resource "azurerm_storage_share" "garm_share" {
   name                 = "garm-etc-folder"
   storage_account_name = azurerm_storage_account.garm_sa.name
   quota                = 10
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "random_password" "garm_jwt_secret" {

--- a/github/azure-self-hosted-runners/tf/variables.tf
+++ b/github/azure-self-hosted-runners/tf/variables.tf
@@ -22,12 +22,6 @@ variable "caddy_image" {
   description = "Container image for caddy"
 }
 
-variable "storage_account_name" {
-  type        = string
-  default     = "cocogarmstorage"
-  description = "Name for storage account"
-}
-
 variable "github_token" {
   type        = string
   description = "Github token for garm"


### PR DESCRIPTION
GARM is a stateful system, backed by a sqlite file on a file share. The file share infra is managed by terraform, As we don't want to drop the file share when iterating on an existing terraform deployment, a deletion prevention annotation has been added. Also a stale variable has been removed.