### PR TITLE
garm: use ghcr.io/confidential-containers/garm:main

### DIFF
--- a/github/azure-self-hosted-runners/tf/variables.tf
+++ b/github/azure-self-hosted-runners/tf/variables.tf
@@ -12,7 +12,7 @@ variable "location" {
 
 variable "garm_image" {
   type        = string
-  default     = "ghcr.io/mkulke/garm:20230602"
+  default     = "ghcr.io/confidential-containers/garm:main"
   description = "Container image for garm"
 }
 


### PR DESCRIPTION
As we have workflow to build our garm image, makes sense to use it.