### PR TITLE
garm: allow multiple github config entries

### DIFF
--- a/github/azure-self-hosted-runners/Dockerfile
+++ b/github/azure-self-hosted-runners/Dockerfile
@@ -18,9 +18,9 @@ RUN go build -o /build/garm-provider-azure
 
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 	ca-certificates \
-	gettext-base
+	python3-jinja2
 
 RUN mkdir -p /etc/garm /root/.local/share/garm-cli
 RUN ln -s /etc/garm/cli-config.toml /root/.local/share/garm-cli/config.toml
@@ -29,6 +29,6 @@ COPY --from=builder /build/garm /usr/bin
 COPY --from=builder /build/garm-cli /usr/bin
 COPY --from=builder /build/garm-provider-azure /usr/bin
 
-COPY ./config.toml.tmpl /
-COPY ./azure-config.toml.tmpl /
+COPY ./templates /templates
+COPY ./template_config.py /
 COPY ./init.sh /

--- a/github/azure-self-hosted-runners/README.md
+++ b/github/azure-self-hosted-runners/README.md
@@ -22,11 +22,19 @@ The application is deployed as an [ACI](https://azure.microsoft.com/en-us/produc
 
 ### Deployment
 
-Create a `tf/terraform.tfvars` file with `github-token=github_pat...` or set it as env `export TF_VAR_github_token=github_pat...`.
+Github tokens (see above) need to be passed to Garm via tf variables, either by creating a `tf/terraform.tfvars` or specifying it on the cli:
+
+```hcl
+github_tokens = [
+	{
+		name = "some name"
+		token = "abc123"
+	},
+]
+```
 
 ```bash
-cd tf
-terraform apply
+terraform apply -var='github_tokens=[{"name":"some name","token":"abc123"}]'
 ```
 
 ## Configuration

--- a/github/azure-self-hosted-runners/azure-config.toml.tmpl
+++ b/github/azure-self-hosted-runners/azure-config.toml.tmpl
@@ -1,7 +1,0 @@
-location = "eastus"
-
-[credentials]
-subscription_id = "$SUBSCRIPTION_ID"
-
-[credentials.managed_identity]
-client_id = "$AZURE_CLIENT_ID"

--- a/github/azure-self-hosted-runners/init.sh
+++ b/github/azure-self-hosted-runners/init.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 : "${GARM_HOSTNAME:?required}"
 : "${GARM_JWT_SECRET:?required}"
 : "${GARM_DB_PASSPHRASE:?required}"
-: "${GITHUB_TOKEN:?required}"
-envsubst < /config.toml.tmpl > /etc/garm/config.toml
+: "${GITHUB_CONFIG:?required}"
+python3 /template_config.py config.toml > /etc/garm/config.toml
 
 : "${SUBSCRIPTION_ID:?required}"
 : "${AZURE_CLIENT_ID:?required}"
-envsubst < /azure-config.toml.tmpl > /etc/garm/azure-config.toml
+python3 /template_config.py azure-config.toml > /etc/garm/azure-config.toml
 
 if [ -f /etc/garm/db.sqlite ]; then
 	echo "database already exists, skipping init"

--- a/github/azure-self-hosted-runners/template_config.py
+++ b/github/azure-self-hosted-runners/template_config.py
@@ -1,0 +1,12 @@
+import os, sys, json
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+template = sys.argv[1]
+environment = Environment(loader=FileSystemLoader("templates/"), undefined=StrictUndefined)
+template = environment.get_template(template)
+
+github_config_json = os.environ['GITHUB_CONFIG']
+github_config = json.loads(github_config_json)
+rendered_config = template.render(env=os.environ, github_config=github_config)
+
+print(rendered_config)

--- a/github/azure-self-hosted-runners/templates/azure-config.toml
+++ b/github/azure-self-hosted-runners/templates/azure-config.toml
@@ -1,0 +1,7 @@
+location = "eastus2"
+
+[credentials]
+subscription_id = "{{ env['SUBSCRIPTION_ID'] }}"
+
+[credentials.managed_identity]
+client_id = "{{ env['AZURE_CLIENT_ID'] }}"

--- a/github/azure-self-hosted-runners/templates/config.toml
+++ b/github/azure-self-hosted-runners/templates/config.toml
@@ -1,3 +1,5 @@
+{# templates/config.toml #}
+
 [default]
 # This URL is used by instances to send back status messages as they install
 # the github actions runner. Status messages can be seen by querying the
@@ -5,7 +7,7 @@
 # Note: If you're using a reverse proxy in front of your garm installation,
 # this URL needs to point to the address of the reverse proxy. Using TLS is
 # highly encouraged.
-callback_url = "https://${GARM_HOSTNAME}/api/v1/callbacks/status"
+callback_url = "https://{{ env['GARM_HOSTNAME'] }}/api/v1/callbacks/status"
 
 # This URL is used by instances to retrieve information they need to set themselves
 # up. Access to this URL is granted using the same JWT token used to send back
@@ -14,7 +16,7 @@ callback_url = "https://${GARM_HOSTNAME}/api/v1/callbacks/status"
 # Note: If you're using a reverse proxy in front of your garm installation,
 # this URL needs to point to the address of the reverse proxy. Using TLS is
 # highly encouraged.
-metadata_url = "https://${GARM_HOSTNAME}/api/v1/metadata"
+metadata_url = "https://{{ env['GARM_HOSTNAME'] }}/api/v1/metadata"
 
 # This folder is defined here for future use. Right now, we create a SSH
 # public/private key-pair.
@@ -40,7 +42,7 @@ disable_auth = false
 [jwt_auth]
 # A JWT token secret used to sign tokens.
 # Obviously, this needs to be changed :).
-secret = "${GARM_JWT_SECRET}"
+secret = "{{ env['GARM_JWT_SECRET'] }}"
 
 # Time to live for tokens. Both the instances and you will use JWT tokens to
 # authenticate against the API. However, this TTL is applied only to tokens you
@@ -74,7 +76,7 @@ time_to_live = "8760h"
   # secret that gets saved to the database, using AES256. In the future, secrets
   # will be saved to something like Barbican or Vault, eliminating the need for
   # this. This setting needs to be 32 characters in size.
-  passphrase = "$GARM_DB_PASSPHRASE"
+  passphrase = "{{ env['GARM_DB_PASSPHRASE'] }}"
   [database.sqlite3]
     # Path on disk to the sqlite3 database file.
     db_file = "/etc/garm/db.sqlite"
@@ -96,26 +98,13 @@ provider_type = "external"
 # is no Vault integration (yet). This will change in the future.
 # Credentials defined here can be listed using the API. Obviously, only the name
 # and descriptions are returned.
+{% for config in github_config %}
 [[github]]
-  name = "garm"
-  description = "garm pat"
-  # This is a personal token with access to the repositories and organizations
-  # you plan on adding to garm. The "workflow" option needs to be selected in order
-  # to work with repositories, and the admin:org needs to be set if you plan on
-  # adding an organization.
-  oauth2_token = "$GITHUB_TOKEN"
-  # base_url (optional) is the URL at which your GitHub Enterprise Server can be accessed.
-  # If these credentials are for github.com, leave this setting blank
+  name = "{{ config.name }}"
+  description = ""
+  oauth2_token = "{{ config.token }}"
   base_url = ""
-  # api_base_url (optional) is the base URL where the GitHub Enterprise Server API can be accessed.
-  # Leave this blank if these credentials are for github.com.
   api_base_url = ""
-  # upload_base_url (optional) is the base URL where the GitHub Enterprise Server upload API can be accessed.
-  # Leave this blank if these credentials are for github.com, or if you don't have a separate URL
-  # for the upload API.
   upload_base_url = ""
-  # ca_cert_bundle (optional) is the CA certificate bundle in PEM format that will be used by the github
-  # client to talk to the API. This bundle will also be sent to all runners as bootstrap params.
-  # Use this option if you're using a self signed certificate.
-  # Leave this blank if you're using github.com or if your certificare is signed by a valid CA.
   ca_cert_bundle = ""
+{% endfor %}

--- a/github/azure-self-hosted-runners/tf/main.tf
+++ b/github/azure-self-hosted-runners/tf/main.tf
@@ -93,7 +93,7 @@ resource "azurerm_container_group" "garm_aci" {
       GARM_JWT_SECRET    = random_password.garm_jwt_secret.result
       GARM_DB_PASSPHRASE = random_password.garm_db_passphrase.result
       GARM_ADMIN_PW      = random_password.garm_admin_pw.result
-      GITHUB_TOKEN       = var.github_token
+      GITHUB_CONFIG      = jsonencode(var.github_config)
     }
 
     volume {

--- a/github/azure-self-hosted-runners/tf/variables.tf
+++ b/github/azure-self-hosted-runners/tf/variables.tf
@@ -22,8 +22,11 @@ variable "caddy_image" {
   description = "Container image for caddy"
 }
 
-variable "github_token" {
-  type        = string
-  description = "Github token for garm"
+variable "github_config" {
+  type = list(object({
+    name  = string
+    token = string
+  }))
+  description = "Github configurations"
   sensitive   = true
 }


### PR DESCRIPTION
## Why?

In the current provisioning setup we can only set a single github config/token. Garm is able to manage pools of workers for multiple repos and we want to use it for e.g. the kbs repo

## How?

In the revised code tf will serialize the entries to json and set it as an env. In a jinja2 template it will be parsed into a dict and templated.

From my testing the update should be non-destructive, we don't need to discard an existing garm configuration, we just need to give the existing token the name "garm", since the garm schema references the github credentials [by name](https://github.com/cloudbase/garm/blob/8fe4f17e1ccda402f5094d9b914d460f183e2577/database/sql/models.go#L91C10-L91C10).