### PR TITLE
garm: use var.location in azure provider config

### DIFF
--- a/github/azure-self-hosted-runners/templates/azure-config.toml
+++ b/github/azure-self-hosted-runners/templates/azure-config.toml
@@ -1,4 +1,4 @@
-location = "eastus2"
+location = "{{ env['LOCATION'] }}"
 
 [credentials]
 subscription_id = "{{ env['SUBSCRIPTION_ID'] }}"

--- a/github/azure-self-hosted-runners/tf/main.tf
+++ b/github/azure-self-hosted-runners/tf/main.tf
@@ -87,6 +87,7 @@ resource "azurerm_container_group" "garm_aci" {
       GARM_HOSTNAME   = local.fqdn
       SUBSCRIPTION_ID = data.azurerm_subscription.current.subscription_id
       AZURE_CLIENT_ID = azurerm_user_assigned_identity.garm_id.client_id
+	  LOCATION        = var.location
     }
 
     secure_environment_variables = {


### PR DESCRIPTION
The eastus2 value was hardcoded, which currently is not able to run certain CVM instance sizes.