### PR TITLE
garm: introduce vm_location param

### DIFF
--- a/github/azure-self-hosted-runners/templates/azure-config.toml
+++ b/github/azure-self-hosted-runners/templates/azure-config.toml
@@ -1,4 +1,4 @@
-location = "{{ env['LOCATION'] }}"
+location = "{{ env['VM_LOCATION'] }}"
 
 [credentials]
 subscription_id = "{{ env['SUBSCRIPTION_ID'] }}"

--- a/github/azure-self-hosted-runners/tf/main.tf
+++ b/github/azure-self-hosted-runners/tf/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_container_group" "garm_aci" {
       GARM_HOSTNAME   = local.fqdn
       SUBSCRIPTION_ID = data.azurerm_subscription.current.subscription_id
       AZURE_CLIENT_ID = azurerm_user_assigned_identity.garm_id.client_id
-	  LOCATION        = var.location
+      VM_LOCATION     = var.vm_location
     }
 
     secure_environment_variables = {

--- a/github/azure-self-hosted-runners/tf/variables.tf
+++ b/github/azure-self-hosted-runners/tf/variables.tf
@@ -10,6 +10,12 @@ variable "location" {
   description = "Location for all resources"
 }
 
+variable "vm_location" {
+  type        = string
+  default     = "westeurope"
+  description = "Location for the runner VMs"
+}
+
 variable "garm_image" {
   type        = string
   default     = "ghcr.io/confidential-containers/garm:main"


### PR DESCRIPTION
the current location (eastus) will only support SEV-SNP and nestable instances, if we want to support TDX runners, we have to move to a region that supports all three of them: westeurope is one of those regions.

Since we don't want to invalidate all the urls in the github webhook configurations when moving to another location (garm urls are bound to a location), a discrete `vm_location` param has been introduced that configures GARM to spawn Runners in that region.