### PR TITLE
garm: store github tokens in key vault

### DIFF
--- a/github/azure-self-hosted-runners/tf/variables.tf
+++ b/github/azure-self-hosted-runners/tf/variables.tf
@@ -28,11 +28,7 @@ variable "caddy_image" {
   description = "Container image for caddy"
 }
 
-variable "github_config" {
-  type = list(object({
-    name  = string
-    token = string
-  }))
-  description = "Github configurations"
-  sensitive   = true
+variable "github_token_key_vault_id" {
+  type        = string
+  description = "key vault id holding github token secrets"
 }


### PR DESCRIPTION
Instead of providing a list of name/token pairs as a deployment variable, we will specify a key vault from which all secrets will be read and converted from secret_name/value to name/token pairs.

The logic of converting the name/token pairs to a garm config remains untouched by this change.